### PR TITLE
Update secondary color for better visual contrast on white backgrounds

### DIFF
--- a/scss/_typography.scss
+++ b/scss/_typography.scss
@@ -44,7 +44,7 @@ h6 { @extend %h6; }
 
 // Secondary
 .secondary {
-  color: $gray-300;
+  color: $gray-500;
 }
 
 h1 .secondary,


### PR DESCRIPTION
Currently secondary text does not meet WCAG AA guidelines, and some users may have a difficult time seeing it. Adjusting secondary elements to use `$gray-500` instead of `$gray-300` gives a better contrast ratio of 5.17:1.

See example below for adjusted text:

![screenshot 2016-09-07 19 59 17](https://cloud.githubusercontent.com/assets/1062039/18333569/d673aef6-7535-11e6-9ddf-07cccbd5de34.png)
