### PR TITLE
Create a new powershell deployment script

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,33 @@
+$stageFolder = "stage"
+
+# Create a working tree to modify the gh-pages branch
+git worktree add $stageFolder gh-pages
+
+# Empty the gh-pages branch from it's previous build
+#rm -rf $stageFolder/*
+Remove-Item -Recurse -Force -Exclude .* $stageFolder/*
+
+# Create a new build, move it into the stage folder for gh-pages, 
+# and set the current context to that folder
+grunt build 
+Move-Item docs/build/* $stageFolder 
+Set-Location $stageFolder
+
+# Prepend the basepath to all absolute links for gh-pages
+$files = Get-ChildItem $path -Recurse -Filter ".html"
+foreach($file in $files){
+  $filetext = Get-Content $file.FullName -Raw
+  $filetextNew = $filetext     -replace '(href=\"?\/|src=\"?\/)([^\/])', '$1design/$2'
+  $filetextNew = $filetextNew  -replace "register[(]'\/sw","register('\/design\/sw"
+  Set-Content $file.FullName $filetextNew
+}
+
+# Add all of the changes to the commit, commit the changes, 
+# and push them up to github
+git add --all .
+git commit -m "Deploying to gh-pages"
+git push origin gh-pages --quiet
+
+# Exit the worktree folder and remove the worktree
+Set-Location ..
+git worktree remove $stageFolder

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# !!!!! DO NOT USE !!!!!
+# This was for the old Travis CI tool that would automate the build 
+# process in the Github pages site. This is no longer used. Please 
+# refer to the deployment powershell script in the root of the project 
+# and run with NPM
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "author": "Daxko",
   "license": "MIT",
   "scripts": {
-    "deploy": "cd docs && ./deploy.sh",
-    "test": "grunt mocha"
+    "deploy": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command .\\deploy.ps1",
+    "test": "grunt mocha",
+    "clean": "rm -rf docs/build/*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Create a new powershell deployment script so that the project can be deployed from windows machines. Add a warning to the old Travis CI script to not use this without reworking it first and to instead use the npm deploy command. Add an npm clean script for cleaning out the docs build folder